### PR TITLE
Some entries don't allow comments

### DIFF
--- a/lib/ruby-hackernews/domain/entry/entry.rb
+++ b/lib/ruby-hackernews/domain/entry/entry.rb
@@ -1,4 +1,3 @@
-
 class Entry
 
   attr_reader :number
@@ -51,7 +50,7 @@ class Entry
   end
 
   def comments_count
-    return @comments_info.count
+    return @comments_info.count unless @comments_info.nil?
   end
 
   def write_comment(text)


### PR DESCRIPTION
Raises an exception when trying to access count when @comments_info is nil
