### PR TITLE
Fix second line parsers

### DIFF
--- a/lib/ruby-hackernews/services/parsers/comments_info_parser.rb
+++ b/lib/ruby-hackernews/services/parsers/comments_info_parser.rb
@@ -2,18 +2,27 @@ module RubyHackernews
 
   class CommentsInfoParser
 
-    def initialize(comments_element)
-      @element = comments_element.search("a")[1]
+    def initialize(second_line)
+      @second_line = second_line
     end
 
     def parse
-      comments_info = nil
-      if @element && @element['href'] =~ /id/
-        comments      = @element.inner_html.split[0].to_i
-        comments_page = @element['href']
-        comments_info = CommentsInfo.new(comments, comments_page)
-      end
-      return comments_info
+      return unless comments_link
+
+      comments      = comments_link.text.split[0].to_i
+      comments_page = comments_link['href']
+
+      CommentsInfo.new(comments, comments_page)
+    end
+
+    private
+
+    def comments_link
+      links.find { |link| link.text =~ /comment|discuss/ }
+    end
+
+    def links
+      @second_line.css('a')
     end
 
   end

--- a/lib/ruby-hackernews/services/parsers/entry_parser.rb
+++ b/lib/ruby-hackernews/services/parsers/entry_parser.rb
@@ -20,12 +20,12 @@ module RubyHackernews
       number   = number_segment.inner_html.sub(".","").to_i if number_segment
       link     = LinkInfoParser.new(link_segment).parse
       voting   = VotingInfoParser.new(@first_line.search("td/center/a"), @second_line.search("[@class='subtext']")[0]).parse
-      user     = UserInfoParser.new(@second_line.search("[@class='subtext']")[0]).parse
-      comments = CommentsInfoParser.new(@second_line.search("[@class='subtext']")[0]).parse
-      time     = TimeInfoParser.new(@second_line.search("[@class='subtext']").children[3]).parse
+      user     = UserInfoParser.new(@second_line).parse
+      comments = CommentsInfoParser.new(@second_line).parse
+      time     = TimeInfoParser.new(@second_line).parse
       return Entry.new(number, link, voting, user, comments, time)
     end
-    
+
   end
 
 end

--- a/lib/ruby-hackernews/services/parsers/time_info_parser.rb
+++ b/lib/ruby-hackernews/services/parsers/time_info_parser.rb
@@ -2,18 +2,28 @@ module RubyHackernews
 
   class TimeInfoParser
 
-    def initialize(time_element)
-      @element = time_element
+    def initialize(second_line)
+      @second_line = second_line
     end
 
     def parse
-      if @element
-        value           = @element.text.strip.split[0].to_i
-        unit_of_measure = @element.text.strip.split[1]
-      end
-      return TimeInfo.new(value, unit_of_measure)
+      return unless time_link
+
+      value           = time_link.text.strip.split[0].to_i
+      unit_of_measure = time_link.text.strip.split[1]
+
+      TimeInfo.new(value, unit_of_measure)
     end
 
+    private
+
+    def time_link
+      links.find { |link| link.text =~ /\sago/ }
+    end
+
+    def links
+      @second_line.css('a')
+    end
   end
 
 end

--- a/lib/ruby-hackernews/services/parsers/user_info_parser.rb
+++ b/lib/ruby-hackernews/services/parsers/user_info_parser.rb
@@ -2,17 +2,27 @@ module RubyHackernews
 
   class UserInfoParser
 
-    def initialize(user_element)
-      @element = user_element
+    def initialize(second_line)
+      @second_line = second_line
     end
 
     def parse
-      user_element = @element.search("a")[0]
-      if user_element
-        user_name = user_element.inner_html
-        user_page = user_element['href']
-      end
-      return UserInfo.new(user_name, user_page)
+      return unless user_link
+
+      user_name = user_link.inner_html
+      user_page = user_link['href']
+
+      UserInfo.new(user_name, user_page)
+    end
+
+    private
+
+    def user_link
+      links.find { |link| link['href'] =~ /user\?id=/ }
+    end
+
+    def links
+      @second_line.css('a')
     end
 
   end

--- a/spec/HNAPI/services/entries/parsers/parser_helper.rb
+++ b/spec/HNAPI/services/entries/parsers/parser_helper.rb
@@ -21,14 +21,14 @@ class ParserHelper
     return Nokogiri::HTML.fragment('<a id=up_1645686 href="vote?for=1645686&dir=up&whence=%6e%65%77%73"><img src="http://ycombinator.com/images/grayarrow.gif" border=0 vspace=3 hspace=2></a><a id=down_1645686 href="vote?for=1645686&dir=up&whence=%6e%65%77%73"><img src="http://ycombinator.com/images/grayarrow.gif" border=0 vspace=3 hspace=2></a>'
     ).children
   end
-  
+
   #username     : johnthedebs
   #user page    : user?id=johnthedebs
   #score        : 17
   #comments     : 2
   #comment_page : item?id=1645686
   def self.second_line
-    return Nokogiri::HTML.fragment('<td class="subtext"><span id=score_1645686>17 points</span> by <a href="user?id=johnthedebs">johnthedebs</a> 4 hours ago  | <a href="item?id=1645686">2 comments</a></td>')
+    return Nokogiri::HTML.fragment('<td class="subtext"><span class="score" id="score_1645686">17 points</span> by <a href="user?id=johnthedebs">johnthedebs</a> <a href="item?id=1645686">4 hours ago</a> | <a href="item?id=1645686">2 comments</a></td>')
   end
 
   #username     : johnthedebs
@@ -36,7 +36,7 @@ class ParserHelper
   #score        : 17
   #comment_page : item?id=1645686
   def self.second_line_no_comments_yet
-    return Nokogiri::HTML.fragment('<td class="subtext"><span id=score_1645686>17 points</span> by <a href="user?id=johnthedebs">johnthedebs</a> 4 hours ago  | <a href="item?id=1645686">discuss</a></td>')
+    return Nokogiri::HTML.fragment('<td colspan="2"></td><td class="subtext"><span class="score" id="score_1645686">17 points</span> by <a href="user?id=johnthedebs">johnthedebs</a> <a href="item?id=1645686">4 hours ago</a> | <a href="item?id=1645686">discuss</a></td>')
   end
 
   #username     : johnthedebs
@@ -64,14 +64,14 @@ class ParserHelper
   end
 
   def self.second_line_full
-    return Nokogiri::HTML('<tr><td colspan=2></td><td class="subtext"><span id=score_1645745>59 points</span> by <a href="user?id=dhotson">dhotson</a> 4 hours ago  | <a href="item?id=1645745">5 comments</a></td></tr>')
+    Nokogiri::HTML.fragment('<tr><td colspan=2></td><td class="subtext"><span class="score" id="score_1645745">59 points</span> by <a href="user?id=dhotson">dhotson</a> <a href="item?id=1645745">4 hours ago</a> | <a href="item?id=1645745">5 comments</a></td></tr>')
   end
 
   def self.full_page
     File.open(File.join(File.dirname(__FILE__), 'hn_test_page.html'), 'r') do |file|
       return Nokogiri::HTML(file)
     end
-    
+
   end
 
 end

--- a/spec/HNAPI/services/entries/parsers/time_info_parser_spec.rb
+++ b/spec/HNAPI/services/entries/parsers/time_info_parser_spec.rb
@@ -1,10 +1,11 @@
 require 'spec_helper'
+require File.join(File.dirname(__FILE__), 'parser_helper')
 
 module RubyHackernews
   describe TimeInfoParser do
 
     before :each do
-      @parser = TimeInfoParser.new(stub(:text => " 4 hours ago  | "))
+      @parser = TimeInfoParser.new(ParserHelper.second_line)
     end
 
     describe :parse do
@@ -22,4 +23,3 @@ module RubyHackernews
     end
   end
 end
-


### PR DESCRIPTION
I just tried to use this gem and realized that some of the second line parsers were broken probably due to changes on the markup of Hacker News website. I noticed that most of the parsers were too coupled to the position of the markup elements, so I tried to make them a bit more resilient by using information like their HTML attributes or their content.