### PR TITLE
added link to RapidAPI

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -155,6 +155,8 @@ This will return a new Entry instance. For example:
     
 Will return the HN comment url of the last submitted story of that user
 
+Test on [RapidAPI](https://rapidapi.com/package/HackerNews/functions?utm_source=HackernewsGitHub&utm_medium=button)
+
 == TO DO
 
     Get user info (comments, saved)


### PR DESCRIPTION
I've added a link in your README to HackerNews's functions page in RapidAPI. I've done this for a few HackerNews SDKs to help those who are reading the READMEs, understand and test the API before use.